### PR TITLE
Build fix - removed last mentions of `spacedoc-htmldoc`

### DIFF
--- a/spacedoc-executable/pom.xml
+++ b/spacedoc-executable/pom.xml
@@ -19,11 +19,6 @@
         </dependency>
         <dependency>
             <groupId>in.spcct</groupId>
-            <artifactId>spacedoc-htmldoc</artifactId>
-            <version>1.0-SNAPSHOT</version>
-        </dependency>
-        <dependency>
-            <groupId>in.spcct</groupId>
             <artifactId>spacedoc-cdi</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>


### PR DESCRIPTION
Fix failing builds