### PR TITLE
Added basic caching, moved most debug-level println's to loggers.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 */target/
 
 # local testing
-js/*
+.spacedoc/*
+.idea/
 
 *.html
 *.css

--- a/spacedoc-config/src/main/java/in/spcct/spacedoc/config/Setup.java
+++ b/spacedoc-config/src/main/java/in/spcct/spacedoc/config/Setup.java
@@ -4,6 +4,7 @@ import in.spcct.spacedoc.cdi.Registry;
 import in.spcct.spacedoc.config.internal.FFCConfig;
 import in.spcct.spacedoc.config.internal.GeneralConfig;
 import in.spcct.spacedoc.config.internal.PolyglotConfig;
+import in.spcct.spacedoc.config.internal.RenderCacheConfig;
 import in.spcct.spacedoc.config.loader.Config;
 import in.spcct.spacedoc.config.loader.impls.confwrap.ConfigContextConfigSource;
 import in.spcct.spacedoc.config.loader.impls.confwrap.ConfigWrapperFieldLoader;
@@ -26,6 +27,7 @@ public class Setup {
         loadAndRegister(new FFCConfig());
         loadAndRegister(new GeneralConfig());
         loadAndRegister(new PolyglotConfig());
+        loadAndRegister(new RenderCacheConfig());
     }
 
     private static void loadAndRegister(Config config) {

--- a/spacedoc-config/src/main/java/in/spcct/spacedoc/config/internal/FFCConfig.java
+++ b/spacedoc-config/src/main/java/in/spcct/spacedoc/config/internal/FFCConfig.java
@@ -31,7 +31,7 @@ public class FFCConfig implements Config {
     /**
      *
      */
-    @ConfigProperty(name = "polyglot-j")
+    @ConfigProperty(name = "polyglot-js")
     @Converter(EnumConverter.class)
     private EnableDisableAuto polyglotJs = EnableDisableAuto.AUTO;
 }

--- a/spacedoc-config/src/main/java/in/spcct/spacedoc/config/internal/PolyglotConfig.java
+++ b/spacedoc-config/src/main/java/in/spcct/spacedoc/config/internal/PolyglotConfig.java
@@ -19,7 +19,7 @@ public class PolyglotConfig implements Config {
     /**
      * Directory to be used for require():d NPM modules
      */
-    @ConfigProperty(name = "js.require.directory", defaultValue = "js/require")
+    @ConfigProperty(name = "js.require.directory", defaultValue = ".spacedoc/js/require")
     private String requireCwd;
 
 }

--- a/spacedoc-config/src/main/java/in/spcct/spacedoc/config/internal/RenderCacheConfig.java
+++ b/spacedoc-config/src/main/java/in/spcct/spacedoc/config/internal/RenderCacheConfig.java
@@ -1,0 +1,22 @@
+package in.spcct.spacedoc.config.internal;
+
+import in.spcct.spacedoc.config.ConfigNamespace;
+import in.spcct.spacedoc.config.ConfigProperty;
+import in.spcct.spacedoc.config.loader.Config;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@EqualsAndHashCode(callSuper = false)
+@ConfigNamespace(
+        prefix = "markdown.render-cache"
+)
+public class RenderCacheConfig implements Config {
+
+    @ConfigProperty(name = "cache-directory", defaultValue = ".spacedoc/cache/")
+    private String cacheDirectory;
+
+}

--- a/spacedoc-executable/src/main/java/in/spcct/spacedoc/exec/Main.java
+++ b/spacedoc-executable/src/main/java/in/spcct/spacedoc/exec/Main.java
@@ -2,11 +2,13 @@ package in.spcct.spacedoc.exec;
 
 import in.spcct.spacedoc.cdi.Registry;
 import in.spcct.spacedoc.common.module.Module;
+import lombok.extern.java.Log;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
+@Log
 public class Main {
 
     public static void main(String[] args) throws Exception {
@@ -27,7 +29,10 @@ public class Main {
 
         Module module = lookupModule(moduleName);
 
+        long start = System.currentTimeMillis();
         module.run(stripInitialArgument(args));
+        long end = System.currentTimeMillis();
+        log.info("Run time: " + (end - start) / 1000. + " s");
 
     }
 

--- a/spacedoc-executable/src/main/java/in/spcct/spacedoc/exec/module/MarkdownModule.java
+++ b/spacedoc-executable/src/main/java/in/spcct/spacedoc/exec/module/MarkdownModule.java
@@ -2,7 +2,9 @@ package in.spcct.spacedoc.exec.module;
 
 import in.spcct.spacedoc.cdi.Registry;
 import in.spcct.spacedoc.common.module.Module;
+import in.spcct.spacedoc.common.util.StringUtils;
 import in.spcct.spacedoc.config.ConfigContext;
+import lombok.extern.java.Log;
 import org.apache.commons.cli.*;
 import org.commonmark.Extension;
 import org.commonmark.node.Node;
@@ -17,6 +19,7 @@ import java.util.Properties;
 /**
  * Module for rendering markdown formatted SpaceDoc documents.
  */
+@Log
 public class MarkdownModule implements Module {
 
     private static final ConfigContext configContext = ConfigContext.getInstance();
@@ -134,15 +137,15 @@ public class MarkdownModule implements Module {
         if (commandLine.hasOption("PL")) {
             System.out.println("These entries were actually queried for existence or used:");
             configContext.getQueriedEntries().forEach(
-                    e -> System.out.printf("\t%35s (%12s): %s%n", e.getKey(), e.getSource() == null ? "undefined" : e.getSource(), e.getValue() == null ? "" : e.getValue())
+                    e -> System.out.printf("\t%40s (%12s): %s%n", e.getKey(), e.getSource() == null ? "undefined" : e.getSource(), e.getValue() == null ? "" : e.getValue())
             );
             System.out.println("These values entries were actually used:");
             configContext.getUsedEntries().forEach(
-                    e -> System.out.printf("\t%35s (%12s): %s%n", e.getKey(), e.getSource() == null ? "undefined" : e.getSource(), e.getValue() == null ? "" : e.getValue())
+                    e -> System.out.printf("\t%40s (%12s): %s%n", e.getKey(), e.getSource() == null ? "undefined" : e.getSource(), e.getValue() == null ? "" : e.getValue())
             );
             System.out.println("These entries were defined, but never used:");
             configContext.getUnusedEntries().forEach(
-                    e -> System.out.printf("\t%35s (%12s): %s%n", e.getKey(), e.getSource() == null ? "undefined" : e.getSource(), e.getValue() == null ? "" : e.getValue())
+                    e -> System.out.printf("\t%40s (%12s): %s%n", e.getKey(), e.getSource() == null ? "undefined" : e.getSource(), e.getValue() == null ? "" : e.getValue())
             );
         }
 
@@ -194,7 +197,8 @@ public class MarkdownModule implements Module {
             }
 
         } catch (IOException e) {
-            e.printStackTrace();
+            log.warning("Failed to copy content from a file: " + content.getAbsolutePath() + "\n"
+                    + StringUtils.toStackTraceString(e));
         }
 
     }

--- a/spacedoc-ffc/src/main/java/in/spcct/spacedoc/ffc/cli/WavedromCLI.java
+++ b/spacedoc-ffc/src/main/java/in/spcct/spacedoc/ffc/cli/WavedromCLI.java
@@ -3,6 +3,7 @@ package in.spcct.spacedoc.ffc.cli;
 import in.spcct.spacedoc.common.util.FileUtils;
 import in.spcct.spacedoc.common.util.StringUtils;
 import in.spcct.spacedoc.ffc.Wavedrom;
+import lombok.extern.java.Log;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -15,14 +16,14 @@ import java.util.concurrent.TimeUnit;
  * <p>
  * See https://github.com/wavedrom/cli/
  */
+@Log
 public class WavedromCLI implements Wavedrom {
 
     private File processSVG(String input) throws IOException, InterruptedException {
 
         File inputFile = FileUtils.createTempFile(".json5");
 
-        String x = inputFile.getAbsolutePath();
-        System.out.println(x);
+        log.fine("Wavedrom input file path: " + inputFile.getAbsolutePath());
 
         try (FileWriter fileWriter = new FileWriter(inputFile)) {
             fileWriter.write(input);

--- a/spacedoc-ffc/src/main/java/in/spcct/spacedoc/ffc/js/PolyglotJsRunner.java
+++ b/spacedoc-ffc/src/main/java/in/spcct/spacedoc/ffc/js/PolyglotJsRunner.java
@@ -2,6 +2,7 @@ package in.spcct.spacedoc.ffc.js;
 
 import in.spcct.spacedoc.cdi.Registry;
 import in.spcct.spacedoc.config.internal.PolyglotConfig;
+import lombok.extern.java.Log;
 import org.graalvm.polyglot.Context;
 import org.graalvm.polyglot.Value;
 
@@ -11,9 +12,12 @@ import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
 
+import static in.spcct.spacedoc.common.util.StringUtils.toStackTraceString;
+
 /**
  * A simple wrapper for running JavaScript code via the GraalVM polyglot feature.
  */
+@Log
 public abstract class PolyglotJsRunner {
 
     protected final Context context;
@@ -27,7 +31,7 @@ public abstract class PolyglotJsRunner {
         try {
             Files.createDirectories(requireDir.toPath());
         } catch (IOException e) {
-            e.printStackTrace();
+            log.warning("Exception creating require directories for JS runners\n" + toStackTraceString(e));
         }
 
         Map<String, String> options = new HashMap<>();

--- a/spacedoc-markdown/src/main/java/in/spcct/spacedoc/md/Setup.java
+++ b/spacedoc-markdown/src/main/java/in/spcct/spacedoc/md/Setup.java
@@ -11,6 +11,8 @@ import in.spcct.spacedoc.md.renderer.bitfield.parser.SeparatorParser;
 import in.spcct.spacedoc.md.renderer.bitfield.renderer.FieldTypeRenderer;
 import in.spcct.spacedoc.md.renderer.bitfield.renderer.RegisterRenderer;
 import in.spcct.spacedoc.md.renderer.bitfield.renderer.SeparatorRenderer;
+import in.spcct.spacedoc.md.renderer.cache.CrappyRenderCache;
+import in.spcct.spacedoc.md.renderer.cache.RenderCache;
 import in.spcct.spacedoc.md.renderer.externalcode.instructionset.InstructionSetCodeRenderer;
 import in.spcct.spacedoc.md.renderer.externalcode.memorymap.MemoryMapCodeRenderer;
 import in.spcct.spacedoc.md.renderer.impl.GraphvizSvgRenderer;
@@ -22,10 +24,17 @@ import org.commonmark.ext.gfm.tables.TablesExtension;
 public class Setup {
 
     public static void registerAll() {
+        registerCache();
         registerCommonMarkExtensions();
         registerExternalCodeRenderers();
         registerBitFieldParsers();
         registerBitFieldRenderers();
+    }
+
+    private static void registerCache() {
+        Class<RenderCache> cacheClass = RenderCache.class;
+        //Registry.registerSingleton(cacheClass, 0, RenderCache.NullRenderCache::new);
+        Registry.registerSingleton(cacheClass, 1, CrappyRenderCache::new);
     }
 
     private static void registerCommonMarkExtensions() {

--- a/spacedoc-markdown/src/main/java/in/spcct/spacedoc/md/renderer/ExternalFormatNodeHtmlRenderer.java
+++ b/spacedoc-markdown/src/main/java/in/spcct/spacedoc/md/renderer/ExternalFormatNodeHtmlRenderer.java
@@ -4,6 +4,7 @@ import in.spcct.spacedoc.cdi.Registry;
 import in.spcct.spacedoc.common.util.StringUtils;
 import in.spcct.spacedoc.md.extension.externalformat.ExternalCodeRendererCore;
 import in.spcct.spacedoc.md.renderer.cache.RenderCache;
+import lombok.extern.java.Log;
 import org.commonmark.node.FencedCodeBlock;
 import org.commonmark.node.Node;
 import org.commonmark.renderer.html.CoreHtmlNodeRenderer;
@@ -22,6 +23,7 @@ import java.util.Map;
  * <p>
  * If no renderer for the specified language is found, a fallback to the default renderer occurs.
  */
+@Log
 public class ExternalFormatNodeHtmlRenderer extends FencedCodeBlockRenderer {
 
     private final HtmlNodeRendererContext context;

--- a/spacedoc-markdown/src/main/java/in/spcct/spacedoc/md/renderer/cache/CrappyRenderCache.java
+++ b/spacedoc-markdown/src/main/java/in/spcct/spacedoc/md/renderer/cache/CrappyRenderCache.java
@@ -1,0 +1,81 @@
+package in.spcct.spacedoc.md.renderer.cache;
+
+import in.spcct.spacedoc.cdi.Registry;
+import in.spcct.spacedoc.config.internal.RenderCacheConfig;
+import lombok.SneakyThrows;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Function;
+
+// Mappings:
+// source hash <-> cache file
+public class CrappyRenderCache implements RenderCache {
+
+    private final Set<Integer> cachedSourceHashes = new HashSet<>();
+
+    private final RenderCacheConfig config = Registry.lookup(RenderCacheConfig.class);
+
+    @SneakyThrows
+    public CrappyRenderCache() {
+        //
+        Path cacheDir = Path.of(config.getCacheDirectory());
+        Files.createDirectories(cacheDir);
+        System.out.println("Cache path: " + cacheDir.toAbsolutePath());
+    }
+
+    @Override
+    public String lookupOrGenerate(String sourceCode, Function<String, String> lazyRenderer) {
+        Integer sourceHash = sourceCode.hashCode();
+        String cfn = toCacheFileName(sourceHash);
+        try {
+            if (isCached(sourceHash)) {
+                System.out.println("Cache hit for " + cfn);
+                cachedSourceHashes.add(sourceHash);
+            } else {
+                System.out.println("Cache miss for " + cfn);
+                store(sourceHash, lazyRenderer.apply(sourceCode));
+            }
+            return load(sourceHash);
+        } catch (IOException e) {
+            System.out.println("Cache fault for " + cfn);
+            e.printStackTrace();
+            return lazyRenderer.apply(sourceCode);
+        }
+    }
+
+    private boolean isCached(Integer sourceHash) {
+        return (cachedSourceHashes.contains(sourceHash)
+                || Files.exists(Path.of(config.getCacheDirectory(), toCacheFileName(sourceHash)))
+        );
+    }
+
+    private String load(Integer sourceHash) throws IOException {
+        return Files.readString(
+                toCacheFilePath(sourceHash)
+        );
+    }
+
+    private void store(Integer sourceHash, String rendered) throws IOException {
+        cachedSourceHashes.add(sourceHash);
+        Files.writeString(
+                toCacheFilePath(sourceHash),
+                rendered
+        );
+    }
+
+    private Path toCacheFilePath(Integer sourceHash) {
+        return Path.of(
+                config.getCacheDirectory(),
+                toCacheFileName(sourceHash)
+        );
+    }
+
+    private String toCacheFileName(Integer sourceHash) {
+        return String.format("%08x.cache", sourceHash);
+    }
+
+}

--- a/spacedoc-markdown/src/main/java/in/spcct/spacedoc/md/renderer/cache/RenderCache.java
+++ b/spacedoc-markdown/src/main/java/in/spcct/spacedoc/md/renderer/cache/RenderCache.java
@@ -1,0 +1,32 @@
+package in.spcct.spacedoc.md.renderer.cache;
+
+import java.util.function.Function;
+
+/**
+ * Render cache should provide some way of caching/querying rendered items :)
+ * <p>
+ * The input should be the source code for the figure to be rendered, the output should be the rendered figure as HTML.
+ * Both should be strings.
+ * <p>
+ * Additional context may be somehow provided for use.
+ */
+public interface RenderCache {
+
+    class NullRenderCache implements RenderCache {
+        @Override
+        public String lookupOrGenerate(String code, Function<String, String> lazyRenderer) {
+            return lazyRenderer.apply(code);
+        }
+    }
+
+    /**
+     * Try to look up the rendered version of the given source string in the cache and return it if found.
+     * If nothing's found, call the renderer, store the rendered output into cache, and return it.
+     *
+     * @param code         source code to render
+     * @param lazyRenderer renderer to call if the result is not found in cache yet
+     * @return cached result
+     */
+    String lookupOrGenerate(String code, Function<String, String> lazyRenderer);
+
+}


### PR DESCRIPTION
Should implement most of #28; the cache currently has no logic for deleting old unused entries, however.

This may be tucked on later, and this feature may be split off #28 to its own task.

Other changes:
- Moved `js/require` directory to `.spacedoc/js/require`
- Fixed a typo in `polyglot-js` property name
- Cache is now stored in `.spacedoc/cache`
- Migrated `System.out.println` "logging" to `java.util.logging` clases (Lombok `@Log` annotation)